### PR TITLE
Add .Params.body_is_markdown

### DIFF
--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,9 +1,14 @@
 {{ if .Site.Params.contact.enable }}
+{{ $md := .Params.body_is_markdown | default "false" }}
 <section id="contact" class="wrapper style5">
   <div class="inner">
     <header class="major">
       <h2>{{ .Site.Params.contact.title }}</h2>
+      {{ if $md }}
+      {{ .Site.Params.contact.body | markdownify }}
+      {{ else }}
       <p>{{ .Site.Params.contact.body | safeHTML }}</p>
+      {{ end }}
     </header>
     <form method="post" action="https://formspree.io/{{ .Site.Params.contact.email }}">
       <div class="row gtr-uniform">

--- a/layouts/partials/cta.html
+++ b/layouts/partials/cta.html
@@ -1,9 +1,14 @@
 {{ if .Site.Params.cta.enable }}
+{{ $md := .Params.body_is_markdown | default "false" }}
 <section id="cta" class="wrapper style4">
 	<div class="inner">
 		<header>
       <h2>{{ .Site.Params.cta.title | safeHTML }}</h2>
+      {{ if $md }}
+      {{ .Site.Params.cta.body | markdownify }}
+      {{ else }}
       <p>{{ .Site.Params.cta.body | safeHTML }}</p>
+      {{ end }}
 		</header>
 		<ul class="actions stacked">
       {{ range .Site.Params.cta.link }}

--- a/layouts/partials/one.html
+++ b/layouts/partials/one.html
@@ -1,9 +1,14 @@
 {{ if .Site.Params.one.enable }}
+{{ $md := .Params.body_is_markdown | default "false" }}
 	<section id="one" class="wrapper style1 special">
 		<div class="inner">
 			<header class="major">
         <h2>{{ .Site.Params.one.title | safeHTML}}</h2>
+        {{ if $md }}
+        {{ .Site.Params.one.body | markdownify }}
+        {{ else }}
         <p>{{ .Site.Params.one.body | safeHTML }}</p>
+        {{ end }}
 			</header>
 			<ul class="icons major">
         {{ range .Site.Params.one.icon }}

--- a/layouts/partials/three.html
+++ b/layouts/partials/three.html
@@ -1,9 +1,14 @@
 {{ if .Site.Params.three.enable }}
+{{ $md := .Params.body_is_markdown | default "false" }}
 <section id="three" class="wrapper style3 special">
 	<div class="inner">
 		<header class="major">
       <h2>{{ .Site.Params.three.title | safeHTML }}</h2>
+      {{ if $md }}
+      {{ .Site.Params.three.body_markdown | markdownify }}
+      {{ else }}
       <p>{{ .Site.Params.three.body | safeHTML }}</p>
+      {{ end }}
 		</header>
 		<ul class="features">
       {{ range .Site.Params.three.feature }}

--- a/layouts/partials/two.html
+++ b/layouts/partials/two.html
@@ -1,10 +1,15 @@
 {{ if .Site.Params.two.enable }}
+{{ $md := .Params.body_is_markdown | default "false" }}
 <section id="two" class="wrapper alt style2">
   {{ range .Site.Params.two.section }}
 	<section class="spotlight">
     <div class="image"><img src="{{ .img | relURL }}" alt="" /></div><div class="content">
       <h2>{{ .title | safeHTML }}</h2>
+      {{ if $md }}
+      {{ .body | markdownify }}
+      {{ else }}
       <p>{{ .body | safeHTML }}</p>
+      {{ end }}
 		</div>
 	</section>
   {{ end }}


### PR DESCRIPTION
Setting `.Params.body_is_markdown` to `true` (default value is `false`) will read all `.body` input as markdown text. For wordier pages this makes life a bit easier as you have to write less HTML yourself.