### PR TITLE
Add hooks/head-end.html partial

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,6 +21,7 @@
     {{ partial "stylesheets.html" . }}
     {{ range .Translations }}
     <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}">
+    {{ partial "hooks/head-end.html" . }}
     {{ end }}
 	</head>
 	<body class="landing is-preload">


### PR DESCRIPTION
Quite a few Hugo themes add a head-end partial to allow customising the contents of <head>.