### PR TITLE
Fix markdown switch for front page bodies

### DIFF
--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,5 +1,5 @@
 {{ if .Site.Params.contact.enable }}
-{{ $md := .Params.body_is_markdown | default "false" }}
+{{ $md := .Site.Params.body_is_markdown | default false }}
 <section id="contact" class="wrapper style5">
   <div class="inner">
     <header class="major">

--- a/layouts/partials/cta.html
+++ b/layouts/partials/cta.html
@@ -1,5 +1,5 @@
 {{ if .Site.Params.cta.enable }}
-{{ $md := .Params.body_is_markdown | default "false" }}
+{{ $md := .Site.Params.body_is_markdown | default false }}
 <section id="cta" class="wrapper style4">
 	<div class="inner">
 		<header>

--- a/layouts/partials/one.html
+++ b/layouts/partials/one.html
@@ -1,5 +1,5 @@
 {{ if .Site.Params.one.enable }}
-{{ $md := .Params.body_is_markdown | default "false" }}
+{{ $md := .Site.Params.body_is_markdown | default false }}
 	<section id="one" class="wrapper style1 special">
 		<div class="inner">
 			<header class="major">

--- a/layouts/partials/three.html
+++ b/layouts/partials/three.html
@@ -1,5 +1,5 @@
 {{ if .Site.Params.three.enable }}
-{{ $md := .Params.body_is_markdown | default "false" }}
+{{ $md := .Site.Params.body_is_markdown | default false }}
 <section id="three" class="wrapper style3 special">
 	<div class="inner">
 		<header class="major">

--- a/layouts/partials/two.html
+++ b/layouts/partials/two.html
@@ -1,5 +1,5 @@
 {{ if .Site.Params.two.enable }}
-{{ $md := .Params.body_is_markdown | default "false" }}
+{{ $md := .Site.Params.body_is_markdown | default false }}
 <section id="two" class="wrapper alt style2">
   {{ range .Site.Params.two.section }}
 	<section class="spotlight">


### PR DESCRIPTION
This fixes a regression introduced in
e9d0db22167ccaf3bc43d8cf7e2ea759187081b2. The feature was enabled
instead of disabled by default (`"false"` evaluates to a non-empty string,
which is truthy) and since the front page does not have a `Page`
associated to it, the params for it can’t be set.

@dholbach Please correct me if I’m overlooking something and the feature is usable in its current form.