### PR TITLE
Disable twitter in example content for now

### DIFF
--- a/exampleSite/content/posts/rich-content.md
+++ b/exampleSite/content/posts/rich-content.md
@@ -21,14 +21,6 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ---
 
-## Twitter Simple Shortcode
-
-{{< twitter 1085870671291310081 >}}
-
-<br>
-
----
-
 ## Vimeo Simple Shortcode
 
 {{< vimeo_simple 48912912 >}}


### PR DESCRIPTION
Avoid "Your current API plan does not include access to this endpoint" problem.

```
spectral/exampleSite on  master 
✦ ❯ hugo server -t ../..
Start building sites … 
hugo v0.110.0-e32a493b7826d02763c3b79623952e625402b168+extended linux/amd64 BuildDate=2023-01-17T12:16:09Z VendorInfo=gohugoio
WARN 2023/03/06 18:16:38 The "twitter" shortcode will soon require two named parameters: user and id. See "/home/daniel/dev/spectral/exampleSite/content/posts/rich-content.md:26:1"
ERROR 2023/03/06 18:16:38 Failed to get JSON resource "https://publish.twitter.com/oembed?dnt=false&url=https%3A%2F%2Ftwitter.com%2Fx%2Fstatus%2F1085870671291310081": Failed to retrieve remote file: Forbidden, body: "{\"errors\":[{\"message\":\"Your current API plan does not include access to this endpoint, please see https://developer.twitter.com/en/docs/twitter-api for more information\",\"code\":467}]}\n"
If you feel that this should not be logged as an ERROR, you can ignore it by adding this to your site config:
ignoreErrors = ["error-remote-getjson"]
Error: Error building site: logged 1 error(s)
Built in 231 ms
spectral/exampleSite on  master 
```
