### PR TITLE
Added Google Analytics and SASS

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -4,6 +4,7 @@ languageCode = "en-us"
 defaultContentLanguage = "en"
 paginate = "7"
 theme = "spectral"
+#googleAnalytics = "G-XXXXXXXXXX"
 
 [params]
 fancyTitle = "Spectral" # title for frontpage, may include image
@@ -12,7 +13,6 @@ description = 'Another fine responsive<br />site template freebie<br />crafted b
 startbuttonText = "Activate"
 startbuttonLink = "#"
 body_is_markdown = true
-#google_analytics = "G-XXXXXXXXXX"
 #custom_css = "foo.css"
 #custom_sass = "bar.scss"
 #images = ["path_to_social_image_for_link_previews.jpg"]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -12,7 +12,9 @@ description = 'Another fine responsive<br />site template freebie<br />crafted b
 startbuttonText = "Activate"
 startbuttonLink = "#"
 body_is_markdown = true
+#google_analytics = "G-XXXXXXXXXX"
 #custom_css = "foo.css"
+#custom_sass = "bar.scss"
 #images = ["path_to_social_image_for_link_previews.jpg"]
 
 [[params.menu.main]]

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,6 +11,17 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="referrer" content="origin">
 
+	{{ with .Site.Params.google_analytics }}
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+	<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+	gtag('js', new Date());
+	gtag('config', '{{ . }}');
+	</script>
+	{{ end }}
+
     {{ with .Site.Params.description }}<meta name="description" content="{{ . | plainify }}">{{ end }}
     {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
     {{ range .AlternativeOutputFormats -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,16 +11,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="referrer" content="origin">
 
-	{{ with .Site.Params.google_analytics }}
-	<!-- Google tag (gtag.js) -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
-	<script>
-	window.dataLayer = window.dataLayer || [];
-	function gtag(){dataLayer.push(arguments);}
-	gtag('js', new Date());
-	gtag('config', '{{ . }}');
-	</script>
-	{{ end }}
+	{{ template "_internal/google_analytics.html" . }}
 
     {{ with .Site.Params.description }}<meta name="description" content="{{ . | plainify }}">{{ end }}
     {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}

--- a/layouts/partials/stylesheets.html
+++ b/layouts/partials/stylesheets.html
@@ -8,3 +8,8 @@
 {{ $custom_css := resources.Get . | minify | fingerprint "sha512" }}
 <link rel="stylesheet" href="{{ $custom_css.RelPermalink }}" integrity="{{ $custom_css.Data.Integrity }}">
 {{ end }}
+
+{{ with .Site.Params.custom_sass }}
+{{ $custom_sass := resources.Get . | resources.ToCSS | minify | fingerprint "sha512" }}
+<link rel="stylesheet" href="{{ $custom_sass.RelPermalink }}" integrity="{{ $custom_sass.Data.Integrity }}">
+{{ end }}


### PR DESCRIPTION
I added functionality for SASS generation which is pretty standard in Hugo sites. I also fixed issue #27 by adding support for google analytics. The script it uses for Google analytics is the default, but I'm not sure if it's the correct one. There may be a different more generic script we should use for the analytics part.