### PR TITLE
Changed base URL for github pages

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -16,11 +16,11 @@ body_is_markdown = true
 #images = ["path_to_social_image_for_link_previews.jpg"]
 
 [[params.menu.main]]
-url = '/'
+url = ''
 title = "Home"
 
 [[params.menu.main]]
-url = '/posts/'
+url = 'posts/'
 title = "Posts"
 
 [taxonomies]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "/spectral/"
 title = "Spectral"
 languageCode = "en-us"
 defaultContentLanguage = "en"


### PR DESCRIPTION
To fix issue #24, changed the base URL to `/spectral/` which should prefix any relative paths with `/spectral/`. There's no test branch, but I would recommend testing this deployment before merging to the main branch.