### PR TITLE
layouts/partials: Update header to support Hugo menus

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -17,13 +17,13 @@ body_is_markdown = true
 #custom_sass = "bar.scss"
 #images = ["path_to_social_image_for_link_previews.jpg"]
 
-[[params.menu.main]]
-url = '/'
-title = "Home"
+[[menus.main]]
+pageRef = '/'
+name = "Home"
 
-[[params.menu.main]]
-url = '/posts/'
-title = "Posts"
+[[menus.main]]
+pageRef = '/posts/'
+name = "Posts"
 
 [taxonomies]
     tag = "tags"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,18 +36,20 @@
 				<!-- Header -->
           <header id="header"{{ if .Page.IsHome }} class="alt"{{ end }}>
             <h1><a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a></h1>
+						{{- with index site.Menus "main" }}
 						<nav id="nav">
 							<ul>
 								<li class="special">
                   <a href="#menu" class="menuToggle" aria-label='{{ i18n "menu" }}'><span>{{ i18n "menu" }}</span></a>
 									<div id="menu">
 										<ul>
-				              {{ range .Site.Params.menu.main }}
-				              <li><a href="{{ .url | relURL }}">{{ .title }}</a></li>
-				              {{ end }}
+ 											{{ range . }}
+											<li><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+ 											{{ end }}
 										</ul>
 									</div>
 								</li>
 							</ul>
 						</nav>
+            {{- end }}
 					</header>


### PR DESCRIPTION
The current stable version allows to define menus, hence it's isn't
needed it anymore to define them in the site parameters dictionary.

This commit changes the header to use the Hugo menus for the general
right side menu and adjust the example site to use the Hugo menus to
show that the header changes work as expected.