### PR TITLE
 Adjusted description meta tag content for blogs to improve SEO

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,7 +13,14 @@
 
 	{{ template "_internal/google_analytics.html" . }}
 
-    {{ with .Site.Params.description }}<meta name="description" content="{{ . | plainify }}">{{ end }}
+    {{ $description := "" }}
+      {{ if .Description }}
+        {{ $description = .Description }}
+      {{ else }}
+        {{ $description = .Site.Params.description }}
+    {{ end }}
+    <meta name="description" content="{{ $description }}">
+
     {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
     {{ range .AlternativeOutputFormats -}}
       {{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}


### PR DESCRIPTION
Before:
- blog posts uses the description defined in config.toml, 
After:
- blog posts use descriptions that's defined in md files

![image](https://github.com/sbruder/spectral/assets/68090976/8ebc8173-0cf0-49a1-ad3a-358bdc38e81b)
![image](https://github.com/sbruder/spectral/assets/68090976/fdf4b098-a39d-4a3b-a939-44f2ff6fe49f)
